### PR TITLE
feat: 메인 게시물 리스트 조회 구현 & 공통 에러처리용 핸들러 추가

### DIFF
--- a/src/api/mainPosts/controller/mainPosts.controller.ts
+++ b/src/api/mainPosts/controller/mainPosts.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from "express";
+import * as postService from "../service/mainPosts.service";
+import { MainPostsRequestDto } from "../dto/mainPostsRequest.dto";
+import { handleErrorResponse } from "../../../common/error/custom.errorHandler";
+
+/**
+ * @description 주어진 필터링 조건을 기반으로 게시글 목록 조회
+ * @param {Request} req 필터링 조건을 포함
+ * @param {Response} res 조회된 게시글 목록 반환
+ * @returns {Promise<void>}
+ */
+export const getPostList = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const filters = new MainPostsRequestDto(req.body);
+    const postList = await postService.getPostList(filters);
+
+    res.status(200).json(postList);
+  } catch (error) {
+    handleErrorResponse(error as Error, res, "getPostList");
+  }
+};

--- a/src/api/mainPosts/dto/mainPostsRequest.dto.ts
+++ b/src/api/mainPosts/dto/mainPostsRequest.dto.ts
@@ -1,0 +1,30 @@
+export class MainPostsRequestDto {
+  // 페이지 번호
+  page: number;
+  // 페이지당 게시글 수
+  limit: number;
+
+  // 검색어
+  searchTerm?: string;
+  // 게시글 타입 (탭 구분)
+  postType?: string;
+  // 기술 스택
+  interests?: string[];
+  // 포지션
+  position?: string;
+  // 진행 방식
+  participationMethod?: string;
+  // 작성자 ID
+  userId?: string;
+
+  constructor(data: Partial<MainPostsRequestDto>) {
+    this.page = data.page || 1;
+    this.limit = data.limit || 8;
+    this.searchTerm = data.searchTerm;
+    this.postType = data.postType;
+    this.interests = data.interests ?? [];
+    this.position = data.position;
+    this.participationMethod = data.participationMethod;
+    this.userId = data.userId;
+  }
+}

--- a/src/api/mainPosts/dto/mainPostsResponse.dto.ts
+++ b/src/api/mainPosts/dto/mainPostsResponse.dto.ts
@@ -1,0 +1,31 @@
+export interface MainPostsResponseDto {
+  // Post ID
+  id: string;
+  // 게시글 타입
+  type: string;
+  // 작성자 ID
+  user_id: string;
+  // 게시글 제목
+  title: string;
+  // 게시글 내용
+  content: string;
+  // 기술 스택
+  interests: string[];
+  // 포지션
+  position: string;
+  // 진행 방식
+  participation_method: string;
+  // 작성일
+  created_at: Date;
+
+  // 모집 인원
+  recruitment_capacity?: number | null;
+  // 예상 기간
+  duration?: string | null;
+  // 모집 마감일
+  recruitment_deadline?: Date | null;
+  // 소속
+  affiliation?: string | null;
+  // 가능한 시간대
+  available_time?: string | null;
+}

--- a/src/api/mainPosts/repository/mainPosts.repository.ts
+++ b/src/api/mainPosts/repository/mainPosts.repository.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+import { MainPostsResponseDto } from "../dto/mainPostsResponse.dto";
+
+const prisma = new PrismaClient();
+
+export const getPostList = async (
+  filters: any,
+  page: number,
+  limit: number
+): Promise<MainPostsResponseDto[]> => {
+  const skip = (page - 1) * limit;
+
+  const posts = await prisma.post.findMany({
+    where: filters,
+    skip,
+    take: limit,
+    orderBy: { created_at: "desc" },
+  });
+
+  return posts;
+};

--- a/src/api/mainPosts/service/mainPosts.service.ts
+++ b/src/api/mainPosts/service/mainPosts.service.ts
@@ -1,0 +1,35 @@
+import * as postRepository from "../repository/mainPosts.repository";
+import { MainPostsRequestDto } from "../dto/mainPostsRequest.dto";
+import { MainPostsResponseDto } from "../dto/mainPostsResponse.dto";
+
+export const getPostList = async (
+  filters: MainPostsRequestDto
+): Promise<MainPostsResponseDto[]> => {
+  const queryFilters: any = {};
+
+  // 검색어 있는 경우
+  if (filters.searchTerm) {
+    queryFilters.OR = [
+      { title: { contains: filters.searchTerm, mode: "insensitive" } },
+      { content: { contains: filters.searchTerm, mode: "insensitive" } },
+    ];
+  }
+
+  // 필터링 조건이 있는 경우
+  if (filters.postType) queryFilters.type = filters.postType;
+  if (filters.position) queryFilters.position = filters.position;
+  if (filters.participationMethod)
+    queryFilters.participation_method = filters.participationMethod;
+  if (filters.interests && filters.interests.length > 0) {
+    queryFilters.interests = { hasSome: filters.interests };
+  }
+
+  // 작성글 조회할 경우
+  if (filters.userId) queryFilters.user_id = filters.userId;
+
+  // 페이지네이션
+  const page = filters.page;
+  const limit = filters.limit;
+
+  return await postRepository.getPostList(queryFilters, page, limit);
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,8 @@ import cors from "cors";
 // 라우트 import하실 때 이름 이런식으로 작성해주세요
 import authRoutes from "./routes/auth.routes";
 import userProfileRoutes from "./routes/userProfile.routes";
+import mainPostsRoutes from "./routes/mainPosts.routes";
+import likedPostsRoutes from "./routes/likedPosts.routes";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -18,6 +20,8 @@ app.use(express.json());
 app.use("/api/auth", authRoutes);
 // 사용자 프로필 라우트 설정
 app.use("/api/user-profile", userProfileRoutes);
+// 메인 라우트 설정
+app.use("/api/main", mainPostsRoutes);
 
 // 서버 실행
 app.listen(PORT, () => {

--- a/src/common/error/custom.errorHandler.ts
+++ b/src/common/error/custom.errorHandler.ts
@@ -1,0 +1,34 @@
+import { CustomError, InternalServerError } from "../error/custom.error";
+import { Response } from "express";
+
+/**
+ * @description 특정 컨텍스트에서 발생한 에러를 콘솔에 기록
+ * @param error - 발생한 에러 객체
+ * @param context - 에러가 발생한 컨텍스트(위치나 함수명 등)
+ */
+export const logError = (error: Error, context: string) => {
+  console.error(`Error in ${context}:`, error);
+};
+
+/**
+ * @description 클라이언트 요청 처리 중 발생한 에러에 대한 응답을 전송
+ *              (CustomError의 인스턴스일 경우 지정된 상태 코드와 메시지를, 그렇지 않은 경우 500 상태 코드를 반환)
+ * @param error - 발생한 에러 객체
+ * @param res - Express의 Response 객체
+ * @param context - 에러가 발생한 컨텍스트(위치나 함수명 등)
+ */
+export const handleErrorResponse = (
+  error: Error,
+  res: Response,
+  context: string
+) => {
+  if (error instanceof CustomError) {
+    res.status(error.statusCode).json({ error: error.message });
+  } else {
+    logError(error, context);
+    const internalError = new InternalServerError(
+      `Unexpected error in ${context}`
+    );
+    res.status(internalError.statusCode).json({ error: internalError.message });
+  }
+};

--- a/src/routes/mainPosts.routes.ts
+++ b/src/routes/mainPosts.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { getPostList } from "../api/mainPosts/controller/mainPosts.controller";
+
+const router = Router();
+
+// 메인 게시글 목록 조회
+router.post("/", getPostList);
+
+export default router;


### PR DESCRIPTION
- 메인, 작성글 게시물 리스트 조회 구현 (필터링 조건 포함)
- 공통 에러처리용 함수 파일 추가 (error/custom.errorHandler.ts)
  - catch 에서 공통으로 사용 가능하도록 구성하였으니, 아래 내용 참고해서 적용하시면 중복코드개선 가능합니다ㅎㅎ
```
/**
 * @description 클라이언트 요청 처리 중 발생한 에러에 대한 응답을 전송
 *              (CustomError의 인스턴스일 경우 지정된 상태 코드와 메시지를, 그렇지 않은 경우 500 상태 코드를 반환)
 * @param error - 발생한 에러 객체
 * @param res - Express의 Response 객체
 * @param context - 에러가 발생한 컨텍스트(위치나 함수명 등)
 */
```
```
} catch (error) {
    handleErrorResponse(error as Error, res, "getPostList");
}
```