### PR TITLE
feat: 채팅 서비스와 연동 기능 추가(닉네임)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "^5.21.1",
+    "axios": "^1.7.7",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/src/api/auth/controller/auth.controller.ts
+++ b/src/api/auth/controller/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   deleteUserProfile,
   deleteUserLogin,
   generateToken,
+  syncWithChatService,
 } from "../service/auth.service";
 import { handleErrorResponse } from "../../../common/error/custom.errorHandler";
 import bcrypt from "bcrypt";
@@ -22,6 +23,10 @@ export const createUser = async (
   try {
     const newUserProfile = await createUserProfile(email, nickname);
     await createUserLogin(newUserProfile.email, password);
+
+    if (newUserProfile) {
+      syncWithChatService(newUserProfile.email, newUserProfile.nickname);
+    }
 
     const token = generateToken(newUserProfile.id);
 

--- a/src/api/auth/controller/auth.controller.ts
+++ b/src/api/auth/controller/auth.controller.ts
@@ -25,6 +25,9 @@ export const createUser = async (
     await createUserLogin(newUserProfile.email, password);
 
     if (newUserProfile) {
+      /**
+       * TODO: 채팅서비스가 죽었을 경우 같이 죽는 문제 fix 필요
+       */
       syncWithChatService(newUserProfile.email, newUserProfile.nickname);
     }
 

--- a/src/api/auth/service/auth.service.ts
+++ b/src/api/auth/service/auth.service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import axios from "axios";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 
@@ -67,4 +68,17 @@ export const generateToken = (userId: string) => {
   return jwt.sign({ userId }, process.env.JWT_SECRET as string, {
     expiresIn: "1h",
   });
+};
+
+export const syncWithChatService = async (
+  user_id: string,
+  user_nickname: string
+) => {
+  const userData = {
+    user_id: user_id, // user_id를 email로 설정
+    user_nickname: user_nickname, // nickname 사용
+  };
+  //SEVER URL은 임시
+  // /register/nickname API에 POST 요청
+  await axios.post("http://59.8.137.118:5172/register/nickname", userData);
 };


### PR DESCRIPTION
1. 최초 회원 가입시에 채팅 서비스 쪽에 닉네임을 등록하도록 기능을 추가하였습니다.
관련하여 이후 마이페이지에서 닉네임을 변경할 때도 해당 함수를 호출해야 하는데 이 부분은 이후에 작업할 것 같습니다.

2. 서버URL이 지금 제 로컬PC IP로 고정되어있는데 이 부분은 시연 할 때 까지는 일단 두는 것 으로하겠습니다. 